### PR TITLE
update style to switch land and water to render land polygons on top of water

### DIFF
--- a/mbgl-antique-style.json
+++ b/mbgl-antique-style.json
@@ -10,17 +10,24 @@
   },
   "layers":[
     {
-      "paint":{"background-pattern":"background"},
+      "paint":{"background-color":"#aecad0"},
       "id":"background",
       "source":"antique",
       "source-layer":"background",
       "type":"background"
     },
     {
-      "paint":{"fill-color":"#aecad0"},
-      "id":"ocean",
+      "paint":{"fill-pattern":"background"},
+      "id":"land",
       "source":"antique",
-      "source-layer":"ocean",
+      "source-layer":"land",
+      "type":"fill"
+    },
+    {
+      "paint":{"fill-color":"#aecad0"},
+      "id":"water",
+      "source":"antique",
+      "source-layer":"water",
       "type":"fill"
     },
     {

--- a/mbgl-map.js
+++ b/mbgl-map.js
@@ -134,6 +134,7 @@ document.addEventListener("DOMContentLoaded", function(){
   }));
 
   const layersToFilter = [
+      "water",
       "buildings",
       "building_names",
       "building_names__1",


### PR DESCRIPTION
This PR changes the style so that water is now the background and land polygons can be rendered on top of it. Assumes land is a layer in the vector tiles. 

It also adds water to the filter list so that any extra water polygons with dates can be filtered. 
