### PR TITLE
update mabboxgl libraries

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
   <script src="./map.js"></script>
   <link rel="stylesheet" type="text/css" href="map.css" />
   <link rel="stylesheet" type="text/css" href="slider.css" />
-  <script src='./mbgl/v1.10.1/mapbox-gl.js'></script>
-  <link href='./mbgl/v1.10.1/mapbox-gl.css' rel='stylesheet' />
+  <script src='./mbgl/v1.12.0/mapbox-gl.js'></script>
+  <link href='./mbgl/v1.12.0/mapbox-gl.css' rel='stylesheet' />
   <script src='./mbgl/mapbox-gl-inspect/v1.3.1/mapbox-gl-inspect.js'></script>
   <link href='./mbgl/mapbox-gl-inspect/v1.3.1/mapbox-gl-inspect.css' rel='stylesheet' />
 {% endset %}

--- a/mbgl-index.html
+++ b/mbgl-index.html
@@ -5,8 +5,8 @@
 {% endset %}
 
 {% set headmatter %}
-  <script src='./mbgl/v1.10.1/mapbox-gl.js'></script>
-  <link href='./mbgl/v1.10.1/mapbox-gl.css' rel='stylesheet' />
+  <script src='./mbgl/v1.12.0/mapbox-gl.js'></script>
+  <link href='./mbgl/v1.12.0/mapbox-gl.css' rel='stylesheet' />
 
   <script src='./mbgl/mapbox-gl-inspect/v1.3.1/mapbox-gl-inspect.js'></script>
   <link href='./mbgl/mapbox-gl-inspect/v1.3.1/mapbox-gl-inspect.css' rel='stylesheet' />


### PR DESCRIPTION
This PR updates for mbgl-index.html and index.html to use the latest release libs for mapbox gl. From 1.10.1 to 1.12.0

This is dependant on https://github.com/kartta-labs/antique/pull/1 which adds in these libraries