### PR TITLE
add ne urban areas to low zooms. Add mid and major roads as lines to …

### DIFF
--- a/mbgl-antique-style.json
+++ b/mbgl-antique-style.json
@@ -45,6 +45,13 @@
       "type":"line"
     },
     {
+      "paint":{"fill-color":"#aeada9",  "fill-opacity":{"stops":[[2,0.6],[9,0.1]]}},
+      "id":"urban_areas",
+      "source":"antique",
+      "source-layer":"urban_areas",
+      "type":"fill"
+    },
+    {
       "paint":{"line-color":"#aeada9","line-width":{"stops":[[14,1],[21,3]]}},
       "id":"state_lines",
       "source":"antique",
@@ -87,7 +94,29 @@
       "maxzoom":20
     },
     {
-      "paint":{"line-color":"#444444","line-width":{"stops":[[14,6],[19,29]]}},
+      "paint":{"line-color":"#8f9998","line-width":{"stops":[[10,1],[13,3]]}},
+      "source-layer":"roads",
+      "id":"major_roads_line",
+      "source":"antique",
+      "type":"line",
+      "filter": ["in", ["get", "type"], ["literal", ["motorway","trunk","primary","secondary"]]],
+      "minzoom":10,
+      "maxzoom":13
+    },
+    {
+      "paint":{"line-color":"#8f9998","line-width":1},
+      "source-layer":"roads",
+      "id":"mid_roads_line",
+      "source":"antique",
+      "type":"line",
+      "filter": [ "match", ["get", "type"], ["trunk","primary","secondary" ],false,true  ],
+      "minzoom":10,
+      "maxzoom":13
+    },
+
+
+    {
+      "paint":{"line-color":"#444444","line-width":{"stops":[[14,8],[19,29]]}},
       "source-layer":"roads",
       "id":"roads_casing_major",
       "source":"antique",

--- a/mbgl-map.js
+++ b/mbgl-map.js
@@ -142,6 +142,8 @@ document.addEventListener("DOMContentLoaded", function(){
       "landuse",
       "road_names",
       "minor_roads",
+      "major_roads_line",
+      "mid_roads_line",
       "roads_casing_major",
       "roads_casing_mid",
       "roads_casing_major",


### PR DESCRIPTION
…mid zooms

urban areas at low zooms, from natural earth

![image](https://user-images.githubusercontent.com/48941/95684929-9da5ac80-0bec-11eb-8e09-0551d15de5dc.png)


at mid zooms, major and mid roads are styled as a line:
![image](https://user-images.githubusercontent.com/48941/95684972-dd6c9400-0bec-11eb-9be3-8055363f9eca.png)

These roads layers are added to the filter too. 

This PR needs the associated PR in the antique repo which adds the urban areas to the vector tiles, and changes the zoom for the roads https://github.com/kartta-labs/antique/pull/3