### PR TITLE
fix flexbox styling for safari browser

### DIFF
--- a/mbgl-map.css
+++ b/mbgl-map.css
@@ -17,7 +17,7 @@
 
 #map {
   overflow: hidden;
-  position: relative;
+  position: absolute;
   top: 0;
   left: 0;
     width:100%;
@@ -110,7 +110,7 @@ canvas.mapboxgl-canvas.crosshair-cursor {
 
 
 #map-wrapper {
-  position: relative;
+  position: absolute;
   margin: 0;
   padding: 0;
   width: 100%;


### PR DESCRIPTION
This PR fixes the CSS file mbgl-map.css  used in the mbgl-index.html so that Safari browser can load the map correctly. 