### PR TITLE
To fix arabic road names. This adds the mapbox rtl plugin for the map. Change road names font to noto sans.

### DIFF
--- a/mbgl-antique-style.json
+++ b/mbgl-antique-style.json
@@ -194,7 +194,7 @@
     },
     {
       "layout":{
-        "text-font":["PT Sans Regular"],
+        "text-font":["Noto Sans Regular"],
         "symbol-placement":"line-center",
         "text-field":"{name}",
 
@@ -202,7 +202,7 @@
         "text-letter-spacing":0.2,
         "text-offset":[0,0],
         "text-keep-upright":true,
-        "text-size":{"stops":[[14,10],[19,22]]}
+        "text-size":{"stops":[[14,5],[19,22]]}
       },
       "paint":{"text-color":"#444444","text-halo-color":"#e8e0c8","text-halo-width":2},
       "id":"road_names",

--- a/mbgl-map.js
+++ b/mbgl-map.js
@@ -113,6 +113,8 @@ document.addEventListener("DOMContentLoaded", function(){
 //  ];
 //  const mapFilters = ['all', filterStart, filterEnd];
 
+  mapboxgl.setRTLTextPlugin('./mbgl/mapbox-gl-rtl-text/mapbox-gl-rtl-text.min.js');
+
   const map = new mapboxgl.Map({
       container: 'map', // container id
       style: styleURL, // stylesheet location


### PR DESCRIPTION
Refs #27 

It also makes the zoomed out font size a bit smaller so it fits in the road better. As the previous font was larger. 

This is dependent on https://github.com/kartta-labs/antique/pull/5  which adds the mapbox rtl plugin and font glyphs