### PR TITLE
cache and merge in new annotations with already loaded data

### DIFF
--- a/mbgl-photomap.js
+++ b/mbgl-photomap.js
@@ -329,9 +329,20 @@ class PhotoMapControl {
      }).then(response => {
        return response.json();
      }).then(result => {
-       this.annotations = this.photoAnnotations(result);
-       this.anno_ids = this.idsFromAnnotations(this.annotations)
+       //merge in new annotations with existing
+       const merged_anno = this.annotations.concat(this.photoAnnotations(result)); 
+       //remove duplicates
+       let deduped = [];
+       merged_anno.forEach(function(obj) {
+         let index = deduped.findIndex(x => x.buildingId === obj.buildingId);
+         if (index == -1) {
+           deduped.push(obj);
+         } 
+       });
+       this.annotations = deduped;
 
+       this.anno_ids = this.idsFromAnnotations(this.annotations);
+   
        this.updateFeatureState(this.getMultipolygons(result));
        
        this.showPhotoStyle();    


### PR DESCRIPTION
This PR makes it so when annotation data is requested, it keeps, merges in, and removes duplicates with any existing data instead of just overwriting with new data.  This means that a user, if they panned back to an area of the map they have already visited, should not see a few ms of no data while data is being requested and should see the previous style.




